### PR TITLE
Add Typeclassopedia to the Resources Bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,5 @@ Haskell on [Stack Overflow](http://stackoverflow.com/questions/tagged?tagnames=h
 [How I Start: Haskell](http://howistart.org/posts/haskell/1) - how to set-up a new Haskell project
 
 [Oliver Charles's Blog](https://ocharles.org.uk/blog/) - including 24 Days of Hackage
+
+[Typeclassopedia](https://wiki.haskell.org/Typeclassopedia) - a starting point for the student of Haskell wishing to gain a firm grasp of its standard type classes


### PR DESCRIPTION
Description taken verbatim from the Abstract.

I've found the Typeclassopedia very helpful as a centralized source of information on the most common Haskell typeclasses I've encountered. Plus it's one of the most recommended reading items in the community as far as I know, so it couldn't hurt to have it up here.
